### PR TITLE
音響エンジニアプロファイルのスキルセクションを削除

### DIFF
--- a/src/data/profiles.js
+++ b/src/data/profiles.js
@@ -117,34 +117,6 @@ export const profiles = {
         { icon: '🎓', title: '学歴', value: '音響技術専門学校卒業' }
       ]
     },
-    skills: [
-      {
-        category: 'レコーディング',
-        items: [
-          'Pro Tools',
-          'Logic Pro',
-          'Ableton Live',
-          'マイクロフォン技術'
-        ]
-      },
-      {
-        category: 'ミキシング・マスタリング',
-        items: [
-          'ミキシング',
-          'マスタリング',
-          'アナログ機材',
-          'プラグイン処理'
-        ]
-      },
-      {
-        category: 'その他',
-        items: [
-          'ライブPA',
-          '音響デザイン',
-          '音響機材メンテナンス'
-        ]
-      }
-    ],
     equipment: [
       {
         category: 'PC',


### PR DESCRIPTION
## 概要

音響エンジニアプロファイルからスキルセクションを削除しました。

## 変更内容

- `src/data/profiles.js` の音響エンジニアプロファイルから `skills` フィールドを削除
  - レコーディング（Pro Tools、Logic Pro、Ableton Live、マイクロフォン技術）
  - ミキシング・マスタリング（ミキシング、マスタリング、アナログ機材、プラグイン処理）
  - その他（ライブPA、音響デザイン、音響機材メンテナンス）

## 備考

`equipment` セクションはそのまま残っています。