### PR TITLE
feat: PRプレビュー機能を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,12 +7,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: "pages"
+  group: pages-main
   cancel-in-progress: false
 
 jobs:
@@ -34,18 +32,9 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          keep_files: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,116 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with PR-specific base path
+        env:
+          VITE_BASE_PATH: /my-profile/pr-${{ github.event.number }}/
+        run: npm run build
+
+      - name: Deploy PR preview to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: pr-${{ github.event.number }}
+          keep_files: true
+
+      - name: Post preview URL comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const previewUrl = `https://keigo-hisazumi.github.io/my-profile/pr-${prNumber}/`;
+            const marker = '<!-- pr-preview -->';
+            const body = [
+              marker,
+              '## プレビュー環境 🚀',
+              '',
+              `| | |`,
+              `|---|---|`,
+              `| **プレビューURL** | [${previewUrl}](${previewUrl}) |`,
+              `| **コミット** | \`${context.sha.slice(0, 7)}\` |`,
+              '',
+              '*コードをプッシュするたびに自動更新されます。*',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Remove preview directory from gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git ls-remote --exit-code origin gh-pages; then
+            echo "gh-pages branch does not exist, skipping cleanup"
+            exit 0
+          fi
+
+          git fetch origin gh-pages
+          git checkout gh-pages
+
+          if [ -d "pr-${{ github.event.number }}" ]; then
+            git rm -rf "pr-${{ github.event.number }}"
+            git commit -m "chore: remove PR #${{ github.event.number }} preview"
+            git push origin gh-pages
+          else
+            echo "Preview directory pr-${{ github.event.number }} not found, skipping"
+          fi

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-  base: '/my-profile/',
+  base: process.env.VITE_BASE_PATH || '/my-profile/',
   build: {
     outDir: 'dist'
   }


### PR DESCRIPTION
## Summary

sns-memoのPRプレビュー機能を参考に、my-profileにも同様の仕組みを導入します。

- `vite.config.js`: `VITE_BASE_PATH` 環境変数でベースパスを切り替えられるよう更新
- `.github/workflows/deploy.yml`: `peaceiris/actions-gh-pages@v4` を使う方式に変更（sns-memoと同方式）
- `.github/workflows/pr-preview.yml`: 新規追加。PRごとに `gh-pages` ブランチの `pr-{番号}/` サブディレクトリにデプロイし、PRコメントにプレビューURLを投稿

## 動作

| イベント | 動作 |
|---|---|
| PR作成・更新 | ビルド → `gh-pages/pr-{番号}/` にデプロイ → PRコメントにURLを投稿 |
| PR追加プッシュ | 自動再デプロイ・コメント更新 |
| PRクローズ | `gh-pages` からプレビューディレクトリを削除 |

プレビューURL例: `https://keigo-hisazumi.github.io/my-profile/pr-1/`

## ⚠️ 注意事項

`deploy.yml` を `actions/deploy-pages` から `peaceiris/actions-gh-pages@v4` に変更しています。マージ後、リポジトリの **Settings > Pages > Source** を **「GitHub Actions」から「Deploy from a branch (gh-pages)」** に変更する必要があります。

https://claude.ai/code/session_01EqRutUPwRHkLVpKfbAPhG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqRutUPwRHkLVpKfbAPhG3)_