### PR TITLE
fix: 音響ページではスキルセクションを非表示にする

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
     <main class="container">
       <Hero :profileData="profileData.hero" />
       <About :profileData="profileData.about" />
-      <Skills :profileData="profileData.skills" />
+      <Skills v-if="profileData.skills" :profileData="profileData.skills" />
       <Equipment v-if="profileData.equipment" :profileData="profileData.equipment" />
       <Portfolio :profileData="profileData.portfolio" />
       <Contact />


### PR DESCRIPTION
## 概要

- 音響エンジニア（`soundEngineer`）プロファイル表示時に、スキルセクションを非表示にする

## 変更内容

`App.vue` の `Skills` コンポーネントに `v-if="profileData.skills"` を追加。`Equipment` コンポーネントと同じパターンで、プロファイルデータに `skills` が存在しない場合はセクションを描画しないようにした。

`soundEngineer` プロファイルにはもともと `skills` データがないため、この変更により音響ページでスキルセクションが非表示になる。

## テスト計画

- [ ] Web デベロッパープロファイルではスキルセクションが表示されること
- [ ] 音響エンジニアプロファイルではスキルセクションが表示されないこと
- [ ] Equipment など他のセクションに影響がないこと

https://claude.ai/code/session_0146escW3CM6VHK9GFHU16db

---
_Generated by [Claude Code](https://claude.ai/code/session_0146escW3CM6VHK9GFHU16db)_