### PR TITLE
feat: 音響と開発を別 URL で表示（Vue Router 導入）

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Profile</title>
+    <script>
+      // GitHub Pages SPA: 404.html からのリダイレクトを元のパスに復元する
+      (function(l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&');
+          });
+          window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + decoded[0] +
+            (decoded[1] ? '?' + decoded[1] : '') +
+            l.hash
+          );
+        }
+      }(window.location));
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
         "vite": "^7.1.12",
-        "vue": "^3.5.22"
+        "vue": "^3.5.22",
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "eslint": "^10.2.1",
@@ -1036,6 +1037,12 @@
         "@vue/compiler-dom": "3.5.22",
         "@vue/shared": "3.5.22"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.22",
@@ -2169,6 +2176,21 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@vitejs/plugin-vue": "^6.0.1",
     "vite": "^7.1.12",
-    "vue": "^3.5.22"
+    "vue": "^3.5.22",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "eslint": "^10.2.1",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>My Profile</title>
+  <script>
+    // GitHub Pages SPA リダイレクト
+    // pathSegmentsToKeep=1 はリポジトリ名 (/my-profile/) を保持する
+    var pathSegmentsToKeep = 1;
+    var l = window.location;
+    l.replace(
+      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+      l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+      l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+      (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+      l.hash
+    );
+  </script>
+</head>
+<body></body>
+</html>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,8 @@
 <template>
   <div class="app">
-    <Header :currentProfile="currentProfile" @toggle-profile="toggleProfile" />
+    <Header :currentProfile="currentProfile" />
     <main class="container">
-      <Hero :profileData="profileData.hero" />
-      <About :profileData="profileData.about" />
-      <Skills v-if="profileData.skills" :profileData="profileData.skills" />
-      <Equipment v-if="profileData.equipment" :profileData="profileData.equipment" />
-      <Portfolio :profileData="profileData.portfolio" />
-      <Contact />
+      <router-view />
     </main>
     <Footer />
   </div>
@@ -15,41 +10,14 @@
 
 <script>
 import Header from './components/Header.vue'
-import Hero from './components/Hero.vue'
-import About from './components/About.vue'
-import Skills from './components/Skills.vue'
-import Equipment from './components/Equipment.vue'
-import Portfolio from './components/Portfolio.vue'
-import Contact from './components/Contact.vue'
 import Footer from './components/Footer.vue'
-import { profiles } from './data/profiles.js'
 
 export default {
   name: 'App',
-  components: {
-    Header,
-    Hero,
-    About,
-    Skills,
-    Equipment,
-    Portfolio,
-    Contact,
-    Footer
-  },
-  data() {
-    return {
-      currentProfile: 'soundEngineer',
-      profiles: profiles
-    }
-  },
+  components: { Header, Footer },
   computed: {
-    profileData() {
-      return this.profiles[this.currentProfile]
-    }
-  },
-  methods: {
-    toggleProfile() {
-      this.currentProfile = this.currentProfile === 'webDeveloper' ? 'soundEngineer' : 'webDeveloper'
+    currentProfile() {
+      return this.$route.meta?.profile || 'soundEngineer'
     }
   }
 }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -10,7 +10,12 @@
         </button>
         <ul class="nav-links" :class="{ active: isMenuOpen }">
           <li><a href="#about" @click="closeMenu">About</a></li>
-          <li><a href="#skills" @click="closeMenu">Skills</a></li>
+          <li v-if="currentProfile === 'soundEngineer'">
+            <a href="#equipment" @click="closeMenu">Equipment</a>
+          </li>
+          <li v-else>
+            <a href="#skills" @click="closeMenu">Skills</a>
+          </li>
           <li><a href="#portfolio" @click="closeMenu">Portfolio</a></li>
           <li><a href="#contact" @click="closeMenu">Contact</a></li>
           <li>
@@ -44,8 +49,8 @@ export default {
   },
   computed: {
     toggleTitle() {
-      return this.currentProfile === 'webDeveloper' 
-        ? '音響エンジニアプロフィールに切り替え' 
+      return this.currentProfile === 'webDeveloper'
+        ? '音響エンジニアプロフィールに切り替え'
         : 'Webデベロッパープロフィールに切り替え'
     }
   },
@@ -57,7 +62,8 @@ export default {
       this.isMenuOpen = false
     },
     handleProfileToggle() {
-      this.$emit('toggle-profile')
+      const target = this.currentProfile === 'webDeveloper' ? '/sound' : '/dev'
+      this.$router.push(target)
       this.closeMenu()
     }
   }
@@ -178,7 +184,7 @@ nav {
   .hamburger {
     display: flex;
   }
-  
+
   .nav-links {
     position: fixed;
     left: 0;
@@ -194,23 +200,23 @@ nav {
     overflow: hidden;
     opacity: 0;
   }
-  
+
   .nav-links.active {
     max-height: 400px;
     opacity: 1;
     padding: 1rem 0;
   }
-  
+
   .nav-links li {
     padding: 0.8rem 0;
   }
-  
+
   .nav-links a {
     display: block;
     padding: 0.5rem 0;
     font-size: 1.1rem;
   }
-  
+
   .profile-toggle {
     padding: 0.8rem 1.5rem;
     margin: 0.5rem auto;

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
+import router from './router/index.js'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,28 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import ProfilePage from '../views/ProfilePage.vue'
+
+const routes = [
+  { path: '/', redirect: '/sound' },
+  {
+    path: '/sound',
+    component: ProfilePage,
+    props: { profileKey: 'soundEngineer' },
+    meta: { profile: 'soundEngineer' }
+  },
+  {
+    path: '/dev',
+    component: ProfilePage,
+    props: { profileKey: 'webDeveloper' },
+    meta: { profile: 'webDeveloper' }
+  }
+]
+
+export default createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes,
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) return savedPosition
+    if (to.hash) return { el: to.hash, behavior: 'smooth' }
+    return { top: 0 }
+  }
+})

--- a/src/views/ProfilePage.vue
+++ b/src/views/ProfilePage.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <Hero :profileData="profileData.hero" />
+    <About :profileData="profileData.about" />
+    <Skills v-if="profileData.skills" :profileData="profileData.skills" />
+    <Equipment v-if="profileData.equipment" :profileData="profileData.equipment" />
+    <Portfolio :profileData="profileData.portfolio" />
+    <Contact />
+  </div>
+</template>
+
+<script>
+import Hero from '../components/Hero.vue'
+import About from '../components/About.vue'
+import Skills from '../components/Skills.vue'
+import Equipment from '../components/Equipment.vue'
+import Portfolio from '../components/Portfolio.vue'
+import Contact from '../components/Contact.vue'
+import { profiles } from '../data/profiles.js'
+
+export default {
+  name: 'ProfilePage',
+  components: { Hero, About, Skills, Equipment, Portfolio, Contact },
+  props: {
+    profileKey: {
+      type: String,
+      required: true
+    }
+  },
+  computed: {
+    profileData() {
+      return profiles[this.profileKey]
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## 概要

Vue Router を導入し、音響エンジニアと Web デベロッパーのプロフィールを別々の URL で表示できるようにしました。

- `/sound` → 音響エンジニアプロフィール（機材リスト付き）
- `/dev` → Web デベロッパープロフィール（スキルリスト付き）
- `/`（ルート）→ `/sound` へ自動リダイレクト

## 変更内容

- `vue-router@4` を追加
- `src/router/index.js` を新規作成（`createWebHistory` 使用）
- `src/views/ProfilePage.vue` を新規作成（プロフィールコンテンツをルートコンポーネントとして切り出し）
- `src/App.vue` をレイアウト専用に変更（`<router-view>` でページを切り替え）
- `src/components/Header.vue` を更新
  - トグルボタンのクリックでルーター遷移（`$router.push`）に変更
  - 音響: `Equipment` リンク表示、開発: `Skills` リンク表示
- `public/404.html` を追加（GitHub Pages でのダイレクト URL アクセス対応）
- `index.html` に SPA リダイレクト復元スクリプトを追加

## テスト計画

- [ ] `/sound` で音響エンジニアプロフィールが表示される
- [ ] `/dev` で Web デベロッパープロフィールが表示される
- [ ] `/` にアクセスすると `/sound` へリダイレクトされる
- [ ] トグルボタンで URL が切り替わる
- [ ] 各ページのナビゲーションリンク（About / Skills または Equipment / Portfolio / Contact）が正常に動作する
- [ ] GitHub Pages でのダイレクト URL アクセスが機能する

https://claude.ai/code/session_01SQvgN9nvfJiKHLGnfTL4Jp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQvgN9nvfJiKHLGnfTL4Jp)_