### PR TITLE
fix: dev ページを非表示にし、音響側からの遷移を無効化

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -18,7 +18,7 @@
           </li>
           <li><a href="#portfolio" @click="closeMenu">ポートフォリオ</a></li>
           <li v-if="currentProfile === 'soundEngineer'">
-            <a href="#equipment" @click="closeMenu">機材</a>
+            <a href="#equipment" @click="closeMenu">所持機材</a>
           </li>
           <li v-if="currentProfile === 'webDeveloper'">
             <button @click="handleProfileToggle" class="profile-toggle" :title="toggleTitle">

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -9,16 +9,16 @@
           <span></span>
         </button>
         <ul class="nav-links" :class="{ active: isMenuOpen }">
-          <li><a href="#about" @click="closeMenu">About</a></li>
+          <li><a href="#about" @click="closeMenu">自己紹介</a></li>
           <li v-if="currentProfile === 'soundEngineer'">
             <a href="#pricing" @click="closeMenu">料金表</a>
           </li>
           <li v-if="currentProfile === 'webDeveloper'">
-            <a href="#skills" @click="closeMenu">Skills</a>
+            <a href="#skills" @click="closeMenu">スキル</a>
           </li>
-          <li><a href="#portfolio" @click="closeMenu">Portfolio</a></li>
+          <li><a href="#portfolio" @click="closeMenu">ポートフォリオ</a></li>
           <li v-if="currentProfile === 'soundEngineer'">
-            <a href="#equipment" @click="closeMenu">Equipment</a>
+            <a href="#equipment" @click="closeMenu">機材</a>
           </li>
           <li v-if="currentProfile === 'webDeveloper'">
             <button @click="handleProfileToggle" class="profile-toggle" :title="toggleTitle">

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -18,12 +18,11 @@
           </li>
           <li><a href="#portfolio" @click="closeMenu">Portfolio</a></li>
           <li><a href="#contact" @click="closeMenu">Contact</a></li>
-          <li>
+          <li v-if="currentProfile === 'webDeveloper'">
             <button @click="handleProfileToggle" class="profile-toggle" :title="toggleTitle">
-              <span class="toggle-icon">{{ currentProfile === 'webDeveloper' ? '💻' : '🎵' }}</span>
+              <span class="toggle-icon">🎵</span>
               <span class="toggle-text-stack">
-                <span :style="{ visibility: currentProfile === 'webDeveloper' ? 'visible' : 'hidden' }">Web Dev</span>
-                <span :style="{ visibility: currentProfile !== 'webDeveloper' ? 'visible' : 'hidden' }">音響</span>
+                <span>音響</span>
               </span>
             </button>
           </li>
@@ -49,9 +48,7 @@ export default {
   },
   computed: {
     toggleTitle() {
-      return this.currentProfile === 'webDeveloper'
-        ? '音響エンジニアプロフィールに切り替え'
-        : 'Webデベロッパープロフィールに切り替え'
+      return '音響エンジニアプロフィールに切り替え'
     }
   },
   methods: {
@@ -62,8 +59,7 @@ export default {
       this.isMenuOpen = false
     },
     handleProfileToggle() {
-      const target = this.currentProfile === 'webDeveloper' ? '/sound' : '/dev'
-      this.$router.push(target)
+      this.$router.push('/sound')
       this.closeMenu()
     }
   }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -10,14 +10,13 @@
         </button>
         <ul class="nav-links" :class="{ active: isMenuOpen }">
           <li><a href="#about" @click="closeMenu">About</a></li>
-          <li v-if="currentProfile === 'soundEngineer'">
-            <a href="#equipment" @click="closeMenu">Equipment</a>
-          </li>
-          <li v-else>
+          <li v-if="currentProfile === 'webDeveloper'">
             <a href="#skills" @click="closeMenu">Skills</a>
           </li>
           <li><a href="#portfolio" @click="closeMenu">Portfolio</a></li>
-          <li><a href="#contact" @click="closeMenu">Contact</a></li>
+          <li v-if="currentProfile === 'soundEngineer'">
+            <a href="#equipment" @click="closeMenu">Equipment</a>
+          </li>
           <li v-if="currentProfile === 'webDeveloper'">
             <button @click="handleProfileToggle" class="profile-toggle" :title="toggleTitle">
               <span class="toggle-icon">🎵</span>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -10,6 +10,9 @@
         </button>
         <ul class="nav-links" :class="{ active: isMenuOpen }">
           <li><a href="#about" @click="closeMenu">About</a></li>
+          <li v-if="currentProfile === 'soundEngineer'">
+            <a href="#pricing" @click="closeMenu">料金表</a>
+          </li>
           <li v-if="currentProfile === 'webDeveloper'">
             <a href="#skills" @click="closeMenu">Skills</a>
           </li>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,9 +16,7 @@ const routes = [
   },
   {
     path: '/dev',
-    component: ProfilePage,
-    props: { profileKey: 'webDeveloper' },
-    meta: { profile: 'webDeveloper' }
+    redirect: '/sound'
   }
 ]
 


### PR DESCRIPTION
## 変更内容

- `/dev` ルートへの直接アクセスを `/sound` にリダイレクト
- 音響エンジニアページのナビゲーションからプロフィール切り替えボタンを非表示
- Web Dev ページの切り替えボタンは音響ページへの一方向遷移のみに整理

## 確認事項

- [ ] `/dev` に直接アクセスすると `/sound` にリダイレクトされる
- [ ] 音響ページのナビゲーションに切り替えボタンが表示されない
- [ ] Web Dev ページの切り替えボタンは引き続き音響ページへ遷移できる

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpNA217a8yEFGbsWCzHpmP)_